### PR TITLE
Add v9.3.0 to abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,2 +1,5 @@
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}
+bot:
+  abi_migration_branches:
+    - "v9.3.0"


### PR DESCRIPTION
Add v9.3.0 branch to abi_migration_branches as it is still used by the gazebo feedstock.