### PR TITLE
Remove v10 from abi_migration_branches as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 bot:
-  abi_migration_branches: [v9.3.0, v10, v11]
+  abi_migration_branches: [v9.3.0, v11]
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}


### PR DESCRIPTION
See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md .