### PR TITLE
Fix run_exports for libsdformat13

### DIFF
--- a/.ci_support/linux_64_ruby2.5.yaml
+++ b/.ci_support/linux_64_ruby2.5.yaml
@@ -14,6 +14,17 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.5'
 target_platform:

--- a/.ci_support/linux_64_ruby2.6.yaml
+++ b/.ci_support/linux_64_ruby2.6.yaml
@@ -14,6 +14,17 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.6'
 target_platform:

--- a/.ci_support/linux_aarch64_ruby2.5.yaml
+++ b/.ci_support/linux_aarch64_ruby2.5.yaml
@@ -18,6 +18,17 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.5'
 target_platform:

--- a/.ci_support/linux_aarch64_ruby2.6.yaml
+++ b/.ci_support/linux_aarch64_ruby2.6.yaml
@@ -18,6 +18,17 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.6'
 target_platform:

--- a/.ci_support/linux_ppc64le_ruby2.5.yaml
+++ b/.ci_support/linux_ppc64le_ruby2.5.yaml
@@ -14,6 +14,17 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.5'
 target_platform:

--- a/.ci_support/linux_ppc64le_ruby2.6.yaml
+++ b/.ci_support/linux_ppc64le_ruby2.6.yaml
@@ -14,6 +14,17 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.6'
 target_platform:

--- a/.ci_support/osx_64_ruby2.5.yaml
+++ b/.ci_support/osx_64_ruby2.5.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '10.9'
 c_compiler:
 - clang
 c_compiler_version:
@@ -14,8 +14,17 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.5'
 target_platform:

--- a/.ci_support/osx_64_ruby2.6.yaml
+++ b/.ci_support/osx_64_ruby2.6.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '10.9'
 c_compiler:
 - clang
 c_compiler_version:
@@ -14,8 +14,17 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.6'
 target_platform:

--- a/.ci_support/osx_arm64_ruby2.5.yaml
+++ b/.ci_support/osx_arm64_ruby2.5.yaml
@@ -14,6 +14,16 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.5'
 target_platform:

--- a/.ci_support/osx_arm64_ruby2.6.yaml
+++ b/.ci_support/osx_arm64_ruby2.6.yaml
@@ -14,6 +14,16 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 ruby:
 - '2.6'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,6 +6,17 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.7.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - win-64
 tinyxml2:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About libsdformat13
-===================
+About sdformat13
+================
 
 Home: http://sdformat.org/
 
@@ -118,27 +118,29 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libsdformat13-green.svg)](https://anaconda.org/conda-forge/libsdformat13) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libsdformat13.svg)](https://anaconda.org/conda-forge/libsdformat13) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libsdformat13.svg)](https://anaconda.org/conda-forge/libsdformat13) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libsdformat13.svg)](https://anaconda.org/conda-forge/libsdformat13) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sdformat13-green.svg)](https://anaconda.org/conda-forge/sdformat13) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sdformat13.svg)](https://anaconda.org/conda-forge/sdformat13) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sdformat13.svg)](https://anaconda.org/conda-forge/sdformat13) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sdformat13.svg)](https://anaconda.org/conda-forge/sdformat13) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sdformat13--python-green.svg)](https://anaconda.org/conda-forge/sdformat13-python) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sdformat13-python.svg)](https://anaconda.org/conda-forge/sdformat13-python) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sdformat13-python.svg)](https://anaconda.org/conda-forge/sdformat13-python) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sdformat13-python.svg)](https://anaconda.org/conda-forge/sdformat13-python) |
 
-Installing libsdformat13
-========================
+Installing sdformat13
+=====================
 
-Installing `libsdformat13` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `sdformat13` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libsdformat13` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libsdformat13, sdformat13, sdformat13-python` can be installed with `conda`:
 
 ```
-conda install libsdformat13
+conda install libsdformat13 sdformat13 sdformat13-python
 ```
 
 or with `mamba`:
 
 ```
-mamba install libsdformat13
+mamba install libsdformat13 sdformat13 sdformat13-python
 ```
 
 It is possible to list all of the versions of `libsdformat13` available on your platform with `conda`:
@@ -208,17 +210,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating libsdformat13-feedstock
-================================
+Updating sdformat13-feedstock
+=============================
 
-If you would like to improve the libsdformat13 recipe or build a new
+If you would like to improve the sdformat13 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/libsdformat13-feedstock are
+Note that all branches in the conda-forge/sdformat13-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ outputs:
     script: bld_cxx.bat  # [win]
     build:
       run_exports:
-        - {{ pin_subpackage(name, max_pin='x') }}
+        - {{ pin_subpackage(cxx_name, max_pin='x') }}
 
     requirements:
       build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - 1183.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
The `run_exports` was incorrectly declared for `sdformat13` metapackage instead of for the C++ package `libsdformat13`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
