### PR TITLE
Add v12 to abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,6 +2,7 @@ bot:
   abi_migration_branches:
   - v9
   - v11
+  - v12
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
After the update to v13 I forgot to the create the v12 branch and add it to abi_migration_branches .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
