### PR TITLE
[v12] Bump version to 12.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set base_name = "libsdformat" %}
-{% set version = "12.5.0" %}
+{% set version = "12.6.0" %}
 {% set major_version = version.split('.')[0] %}
 {% set name = base_name + major_version %}
 
@@ -14,8 +14,7 @@ source:
       - skipPoseNoValueTest.patch  # [osx]
 
 build:
-  number: 1
-  skip: false
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
The `ign-gazebo6` branch of `gz-sim` repo requires sdformat 12.6.0, so to test recent PRs such as https://github.com/gazebosim/gz-sim/pull/1764 it is important to bump sdformat to 12.6.0 .

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
