### PR TITLE
Add v14 to abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,6 +3,7 @@ bot:
   - v9
   - v12
   - v13
+  - v14
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
sdformat 14 is part of Gazebo Harmonic (i.e. the gz-sim8 distro, see https://github.com/gazebosim/sdformat/releases/tag/sdformat14_14.0.0), and is supported until Sep 2028, see https://gazebosim.org/docs/latest/releases/ . In https://github.com/conda-forge/libsdformat-feedstock/pull/122 I forgot to add it, this is useful to unblock PRs like https://github.com/conda-forge/gz-sim-feedstock/pull/93 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
